### PR TITLE
Don't sort open nodes on every iteration

### DIFF
--- a/src/a-star.cr
+++ b/src/a-star.cr
@@ -14,7 +14,7 @@ module AStar
     start.f = yield start, goal
 
     until open.empty?
-      current = open.sort! { |a, b| a.f <=> b.f }.first
+      current = open.min_by { |a| a.f }
       return reconstruct_path goal if current == goal
 
       open.delete current


### PR DESCRIPTION
Using min_by instead results in a speedup of 2x-4x